### PR TITLE
Add Visma order management and discount syncing

### DIFF
--- a/app/Filament/Resources/OrderResource.php
+++ b/app/Filament/Resources/OrderResource.php
@@ -1,24 +1,23 @@
 <?php
+
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\OrderResource\Pages;
+use App\Models\Customer;
 use App\Models\Order;
 use App\Models\Products;
-use App\Models\Customer; // Import the Customer model here
-use App\Models\OrderItem;
-use Filament\Forms;
+use App\Services\DiscountService;
+use App\Services\VismaOrderService;
+use Filament\Forms\Components\Card;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Card;
-use Illuminate\Support\Facades\Log;
-use App\Services\DiscountService;
-
-
 
 class OrderResource extends Resource
 {
@@ -28,210 +27,252 @@ class OrderResource extends Resource
     protected static ?string $navigationLabel = 'Orders';
     protected static ?string $navigationGroup = 'Order Management';
 
+    private static ?array $cachedDiscountCodes = null;
+
     public static function form(Form $form): Form
-{
-    return $form
-        ->schema([
-            // Customer Selection Section
+    {
+        return $form->schema([
             Card::make()
+                ->label('Customer')
                 ->schema([
                     Select::make('customer_id')
                         ->label('Customer')
                         ->relationship('customer', 'name')
                         ->required()
-                        ->reactive()
                         ->searchable()
-                        ->afterStateUpdated(function ($state, callable $set) {
-                            // When a customer is selected, populate the address fields
+                        ->reactive()
+                        ->afterStateUpdated(function ($state, callable $set, callable $get): void {
                             $customer = Customer::find($state);
+
                             if ($customer) {
-                                // Populate invoice address fields
                                 $set('invoice_address', $customer->invoice_address_line1 ?? '');
                                 $set('invoice_city', $customer->invoice_city ?? '');
                                 $set('invoice_postal_code', $customer->invoice_postal_code ?? '');
-                                $set('customer_price_class_id', $customer->customer_price_class_id ?? null);
-                                \Log::info('Customer selected:', [
-                                    'customer_id' => $state,
-                                    'customer_price_class_id' => $customer->customer_price_class_id ?? null,
-                                ]);
-
-
-                                // Populate delivery address fields
                                 $set('delivery_address', $customer->delivery_address_line1 ?? '');
                                 $set('delivery_city', $customer->delivery_city ?? '');
                                 $set('delivery_postal_code', $customer->delivery_postal_code ?? '');
-                                $set('customer_price_class_id', $customer->customer_price_class_id ?? '');
-
+                                $set('customer_price_class_id', $customer->customer_price_class_id ?? null);
+                            } else {
+                                $set('invoice_address', null);
+                                $set('invoice_city', null);
+                                $set('invoice_postal_code', null);
+                                $set('delivery_address', null);
+                                $set('delivery_city', null);
+                                $set('delivery_postal_code', null);
+                                $set('customer_price_class_id', null);
                             }
+
+                            self::updateDiscountsForAllItems($set, $get);
                         }),
-                ])
-                ->columns(1)
-                ->label('Customer Details'),
-
-            // Invoice Address Section
-            Card::make()
-                ->schema([
                     TextInput::make('customer_price_class_id')
-                  ->label('Customer Price Class')
-                  ->required(),
-
-
-                    TextInput::make('invoice_address')
-                        ->label('Invoice Address')
-                        ->required(),
-
-                    TextInput::make('invoice_city')
-                        ->label('Invoice City')
-                        ->required(),
-
-                    TextInput::make('invoice_postal_code')
-                        ->label('Invoice Postal Code')
+                        ->label('Customer Price Class')
                         ->required(),
                 ])
-                ->columns(2)
-                ->label('Invoice Address'),
-
-            // Delivery Address Section
+                ->columns(2),
             Card::make()
+                ->label('Invoice Address')
+                ->schema([
+                    TextInput::make('invoice_address')
+                        ->label('Address')
+                        ->required(),
+                    TextInput::make('invoice_city')
+                        ->label('City')
+                        ->required(),
+                    TextInput::make('invoice_postal_code')
+                        ->label('Postal Code')
+                        ->required(),
+                ])
+                ->columns(3),
+            Card::make()
+                ->label('Delivery Address')
                 ->schema([
                     TextInput::make('delivery_address')
-                        ->label('Delivery Address')
+                        ->label('Address')
                         ->required(),
-
                     TextInput::make('delivery_city')
-                        ->label('Delivery City')
+                        ->label('City')
                         ->required(),
-
                     TextInput::make('delivery_postal_code')
-                        ->label('Delivery Postal Code')
+                        ->label('Postal Code')
                         ->required(),
                 ])
-                ->columns(2)
-                ->label('Delivery Address'),
-
-            // Order Items Section
+                ->columns(3),
             Card::make()
+                ->label('Order Lines')
                 ->schema([
                     Repeater::make('items')
                         ->relationship('items')
                         ->schema([
                             Select::make('product_id')
                                 ->label('Product')
-                                ->searchable()
-                                ->options(Products::all()->pluck('name', 'id'))
+                                ->options(fn () => Products::query()->pluck('name', 'id'))
                                 ->required()
+                                ->searchable()
                                 ->reactive()
-                                ->afterStateUpdated(function ($state, callable $set, callable $get) {
-                                    // Get the selected product's price and set the price field
+                                ->afterStateUpdated(function ($state, callable $set, callable $get): void {
                                     if ($state) {
                                         $product = Products::find($state);
-                                        if ($product) {
-                                            $set('price', $product->price);
-                                            $set('item_price_class_id', $product->item_price_class_id);
-
-                                        }
+                                        $set('price', $product?->price);
+                                        $set('item_price_class_id', $product?->item_price_class_id);
+                                    } else {
+                                        $set('price', null);
+                                        $set('item_price_class_id', null);
                                     }
+
+                                    self::applyDiscountToItem($set, $get);
+                                    self::recalculateTotal($set, $get);
                                 }),
-
-                                TextInput::make('quantity')
-                            ->label('Quantity')
-                            ->numeric()
-                            ->default(1) // Set the default value to 1
-                            ->required()
-                            ->reactive()
-                            ->debounce(300) // Reduce debounce time for faster updates
-
-                            ->afterStateUpdated(function ($state, callable $set, callable $get) {
-                                $discountService = app(DiscountService::class);
-
-                                $discountCodes = json_decode(file_get_contents(storage_path('discounts.json')), true);
-                               // $customerPriceClassId = ('FORHANDLER'); // Fetch customer price class ID
-                                $itemPriceClassId = $get('item_price_class_id');
-                                $customerPriceClassId = $get('../../customer_price_class_id');
-
-
-                                $discount = $discountService->getDiscountForCustomerAndProduct(
-                                    $customerPriceClassId,
-                                    $itemPriceClassId,
-                                    $state,
-                                    $discountCodes
-                                );
-
-                                $price = $get('price') ?? 0;
-                                $discountedPrice = $price - ($price * ($discount / 100));
-                                $set('discounted_price', $discountedPrice);
-
-                                \Log::info('Full form state:', $get());
-
-                            }),
-                            TextInput::make('customer_price_class_id')
-    ->label('Customer Price Class ID')
-    ->required()
-    ->hidden(),// Ensure it is part of the form state but not visible
-
-                    
-                            TextInput::make('price')
-                                ->label('Price')
+                            TextInput::make('quantity')
+                                ->label('Quantity')
                                 ->numeric()
-                                ->disabled(), // Original price automatically populated and should not be edited manually
-
-                                TextInput::make('discounted_price')
-            ->label('Discounted Price')
-            ->numeric()
-            ->disabled(), // Price after applying the discount
-
-                                TextInput::make('item_price_class_id')
-                                ->label('item_price_class_id')
+                                ->default(1)
+                                ->minValue(1)
                                 ->required()
-                                ->disabled(), // Automatically populated and should not be edited manuallyng the discount percentage, not applying it
-
-                                
+                                ->reactive()
+                                ->afterStateUpdated(function ($state, callable $set, callable $get): void {
+                                    self::applyDiscountToItem($set, $get);
+                                    self::recalculateTotal($set, $get);
+                                }),
+                            TextInput::make('price')
+                                ->label('Unit Price')
+                                ->numeric()
+                                ->disabled()
+                                ->dehydrated(true),
+                            TextInput::make('discount_percent')
+                                ->label('Discount %')
+                                ->numeric()
+                                ->disabled()
+                                ->default(0)
+                                ->dehydrated(true),
+                            TextInput::make('discount_amount')
+                                ->label('Discount Amount')
+                                ->numeric()
+                                ->disabled()
+                                ->default(0)
+                                ->dehydrated(true),
+                            TextInput::make('discounted_price')
+                                ->label('Discounted Unit Price')
+                                ->numeric()
+                                ->disabled()
+                                ->default(0)
+                                ->dehydrated(true),
+                            TextInput::make('item_price_class_id')
+                                ->label('Item Price Class')
+                                ->disabled()
+                                ->dehydrated(false),
                         ])
-                        ->columns(3)
-                        ->required()
-                        ->reactive()
-                        ->afterStateUpdated(fn ($state, callable $set, callable $get)
-                        
-                        => self::recalculateTotal($set, $get)),
-                        
-                        
-                ])
-                ->label('Order Items'),
-
-            // Total Amount Section
+                        ->columns(6)
+                        ->defaultItems(0)
+                        ->afterStateUpdated(fn ($state, callable $set, callable $get) => self::recalculateTotal($set, $get)),
+                ]),
             Card::make()
+                ->label('Totals')
                 ->schema([
                     TextInput::make('total_amount')
                         ->label('Total Amount')
                         ->numeric()
-                        ->required()
-                        ->disabled(), // Automatically calculated
+                        ->disabled()
+                        ->dehydrated(true),
+                ]),
+            Card::make()
+                ->label('Visma')
+                ->schema([
+                    TextInput::make('visma_sales_order_number')
+                        ->label('Visma Order #')
+                        ->disabled()
+                        ->dehydrated(false),
+                    TextInput::make('visma_status')
+                        ->label('Visma Status')
+                        ->disabled()
+                        ->dehydrated(false),
+                    DateTimePicker::make('visma_last_synced_at')
+                        ->label('Last Synced')
+                        ->disabled()
+                        ->dehydrated(false),
                 ])
-                ->label('Total Amount'),
+                ->columns(3),
         ]);
-}
-
+    }
 
     public static function table(Table $table): Table
     {
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('customer.name')
-                    ->label('Customer Name')
-                    ->sortable(),
-
+                    ->label('Customer')
+                    ->sortable()
+                    ->searchable(),
                 Tables\Columns\TextColumn::make('total_amount')
                     ->label('Total Amount')
-                    ->sortable(),
-
+                    ->sortable()
+                    ->money('NOK'),
                 Tables\Columns\TextColumn::make('status')
                     ->label('Status')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('visma_sales_order_number')
+                    ->label('Visma Order #')
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('visma_status')
+                    ->label('Visma Status')
+                    ->toggleable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('visma_last_synced_at')
+                    ->label('Visma Synced')
+                    ->dateTime()
+                    ->toggleable()
                     ->sortable(),
             ])
             ->filters([
                 //
             ])
             ->actions([
+                Tables\Actions\Action::make('refreshFromVisma')
+                    ->label('Refresh from Visma')
+                    ->icon('heroicon-o-arrow-path')
+                    ->visible(fn (Order $record): bool => filled($record->visma_sales_order_number))
+                    ->action(function (Order $record): void {
+                        try {
+                            $updatedOrder = app(VismaOrderService::class)->syncOrderFromVisma($record->visma_sales_order_number);
+
+                            Notification::make()
+                                ->title('Order refreshed from Visma')
+                                ->body('Sales order ' . $updatedOrder->visma_sales_order_number . ' has been synchronised.')
+                                ->success()
+                                ->send();
+                        } catch (\Throwable $exception) {
+                            report($exception);
+
+                            Notification::make()
+                                ->title('Failed to refresh order from Visma')
+                                ->body($exception->getMessage())
+                                ->danger()
+                                ->send();
+                        }
+                    }),
+                Tables\Actions\Action::make('sendToVisma')
+                    ->label('Send to Visma')
+                    ->icon('heroicon-o-paper-airplane')
+                    ->requiresConfirmation()
+                    ->action(function (Order $record): void {
+                        try {
+                            $updatedOrder = app(VismaOrderService::class)->pushOrderToVisma($record);
+
+                            Notification::make()
+                                ->title('Order sent to Visma')
+                                ->body('Sales order ' . $updatedOrder->visma_sales_order_number . ' synced successfully.')
+                                ->success()
+                                ->send();
+                        } catch (\Throwable $exception) {
+                            report($exception);
+
+                            Notification::make()
+                                ->title('Failed to send order to Visma')
+                                ->body($exception->getMessage())
+                                ->danger()
+                                ->send();
+                        }
+                    }),
                 Tables\Actions\EditAction::make(),
             ])
             ->bulkActions([
@@ -241,42 +282,132 @@ class OrderResource extends Resource
             ]);
     }
 
-    private static function recalculateTotal(callable $set, callable $get)
+    private static function applyDiscountToItem(callable $set, callable $get): void
     {
-        $totalAmount = 0;
-    
-        $items = $get('items') ?? [];
-    
-        if (is_array($items)) {
-            foreach ($items as $item) {
-                $quantity = isset($item['quantity']) && is_numeric($item['quantity'])
-                ? (float) $item['quantity']
-                : 1; // Default to 1 if not provided
-                                $discountedPrice = $item['discounted_price'] ?? 0;
-    
-                $totalAmount += $quantity * $discountedPrice;
-            }
-        }
-    
-        $set('total_amount', $totalAmount);
-        \Log::info('Order Item Data:', [
-            'product_id' => $item['product_id'] ?? null,
-            'quantity' => $item['quantity'] ?? null,
-            'price' => $item['price'] ?? null,
-            'discounted_price' => $item['discounted_price']
-        ]);
-        
+        $quantity = max((float) ($get('quantity') ?? 1), 1);
+        $price = (float) ($get('price') ?? 0);
+        $customerPriceClassId = $get('../../customer_price_class_id');
+        $itemPriceClassId = $get('item_price_class_id');
+
+        $discountPercent = self::resolveDiscountPercent($customerPriceClassId, $itemPriceClassId, $quantity);
+        $discountedPrice = self::calculateDiscountedUnitPrice($price, $discountPercent);
+        $discountAmount = round(($price - $discountedPrice) * $quantity, 2);
+
+        $set('discount_percent', $discountPercent);
+        $set('discount_amount', $discountAmount);
+        $set('discounted_price', $discountedPrice);
     }
-    
 
+    private static function updateDiscountsForAllItems(callable $set, callable $get): void
+    {
+        $items = $get('items') ?? [];
 
+        if (!is_array($items)) {
+            self::recalculateTotal($set, $get);
 
+            return;
+        }
+
+        foreach ($items as $index => $item) {
+            $quantity = max((float) ($item['quantity'] ?? 1), 1);
+            $price = (float) ($item['price'] ?? 0);
+            $itemPriceClassId = $item['item_price_class_id'] ?? null;
+            $customerPriceClassId = $get('customer_price_class_id');
+
+            $discountPercent = self::resolveDiscountPercent($customerPriceClassId, $itemPriceClassId, $quantity);
+            $discountedPrice = self::calculateDiscountedUnitPrice($price, $discountPercent);
+            $discountAmount = round(($price - $discountedPrice) * $quantity, 2);
+
+            $set("items.$index.discount_percent", $discountPercent);
+            $set("items.$index.discount_amount", $discountAmount);
+            $set("items.$index.discounted_price", $discountedPrice);
+        }
+
+        self::recalculateTotal($set, $get);
+    }
+
+    private static function resolveDiscountPercent(?string $customerPriceClassId, ?string $itemPriceClassId, float $quantity): float
+    {
+        if (!filled($customerPriceClassId) || !filled($itemPriceClassId)) {
+            return 0.0;
+        }
+
+        $discountCodes = self::getDiscountCodes();
+
+        if ($discountCodes === []) {
+            return 0.0;
+        }
+
+        /** @var DiscountService $discountService */
+        $discountService = app(DiscountService::class);
+
+        return (float) $discountService->getDiscountForCustomerAndProduct(
+            $customerPriceClassId,
+            $itemPriceClassId,
+            $quantity,
+            $discountCodes
+        );
+    }
+
+    private static function calculateDiscountedUnitPrice(float $price, float $discountPercent): float
+    {
+        if ($discountPercent <= 0) {
+            return round($price, 2);
+        }
+
+        $discounted = $price - ($price * ($discountPercent / 100));
+
+        return round(max($discounted, 0), 2);
+    }
+
+    private static function getDiscountCodes(): array
+    {
+        if (self::$cachedDiscountCodes !== null) {
+            return self::$cachedDiscountCodes;
+        }
+
+        $path = storage_path('discounts.json');
+
+        if (!file_exists($path)) {
+            return self::$cachedDiscountCodes = [];
+        }
+
+        $contents = @file_get_contents($path);
+
+        if ($contents === false) {
+            return self::$cachedDiscountCodes = [];
+        }
+
+        $decoded = json_decode($contents, true);
+
+        return self::$cachedDiscountCodes = is_array($decoded) ? $decoded : [];
+    }
+
+    private static function recalculateTotal(callable $set, callable $get): void
+    {
+        $items = $get('items') ?? [];
+
+        if (!is_array($items) || $items === []) {
+            $set('total_amount', 0);
+
+            return;
+        }
+
+        $total = 0.0;
+
+        foreach ($items as $item) {
+            $quantity = (float) ($item['quantity'] ?? 1);
+            $unitPrice = (float) ($item['discounted_price'] ?? $item['price'] ?? 0);
+
+            $total += $quantity * $unitPrice;
+        }
+
+        $set('total_amount', round($total, 2));
+    }
 
     public static function getRelations(): array
     {
-        return [
-            //
-        ];
+        return [];
     }
 
     public static function getPages(): array
@@ -288,10 +419,3 @@ class OrderResource extends Resource
         ];
     }
 }
-
-
-
-
-
-
-

--- a/app/Filament/Resources/OrderResource/Pages/CreateOrder.php
+++ b/app/Filament/Resources/OrderResource/Pages/CreateOrder.php
@@ -3,10 +3,42 @@
 namespace App\Filament\Resources\OrderResource\Pages;
 
 use App\Filament\Resources\OrderResource;
+use App\Services\VismaOrderService;
 use Filament\Actions;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
+use Throwable;
 
 class CreateOrder extends CreateRecord
 {
     protected static string $resource = OrderResource::class;
+
+    protected function afterCreate(): void
+    {
+        if (!$this->record) {
+            return;
+        }
+
+        try {
+            $order = app(VismaOrderService::class)->pushOrderToVisma(
+                $this->record->fresh(['items.product', 'customer'])
+            );
+
+            $this->record = $order;
+
+            Notification::make()
+                ->title('Order sent to Visma')
+                ->body('Sales order ' . $order->visma_sales_order_number . ' synced successfully.')
+                ->success()
+                ->send();
+        } catch (Throwable $exception) {
+            report($exception);
+
+            Notification::make()
+                ->title('Order created, but Visma sync failed')
+                ->body($exception->getMessage())
+                ->danger()
+                ->send();
+        }
+    }
 }

--- a/app/Filament/Resources/OrderResource/Pages/EditOrder.php
+++ b/app/Filament/Resources/OrderResource/Pages/EditOrder.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\OrderResource\Pages;
 
 use App\Filament\Resources\OrderResource;
+use App\Services\VismaOrderService;
 use Filament\Actions;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use Throwable;
 
 class EditOrder extends EditRecord
 {
@@ -13,6 +16,68 @@ class EditOrder extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('refreshFromVisma')
+                ->label('Refresh from Visma')
+                ->icon('heroicon-o-arrow-path')
+                ->visible(fn (): bool => filled($this->record?->visma_sales_order_number))
+                ->action(function (): void {
+                    if (!$this->record?->visma_sales_order_number) {
+                        return;
+                    }
+
+                    try {
+                        $order = app(VismaOrderService::class)->syncOrderFromVisma($this->record->visma_sales_order_number);
+
+                        $this->record = $order;
+                        $this->fillForm();
+
+                        Notification::make()
+                            ->title('Order refreshed from Visma')
+                            ->body('Sales order ' . $order->visma_sales_order_number . ' has been synchronised.')
+                            ->success()
+                            ->send();
+                    } catch (Throwable $exception) {
+                        report($exception);
+
+                        Notification::make()
+                            ->title('Failed to refresh order from Visma')
+                            ->body($exception->getMessage())
+                            ->danger()
+                            ->send();
+                    }
+                }),
+            Actions\Action::make('sendToVisma')
+                ->label('Send to Visma')
+                ->icon('heroicon-o-paper-airplane')
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    if (!$this->record) {
+                        return;
+                    }
+
+                    try {
+                        $order = app(VismaOrderService::class)->pushOrderToVisma(
+                            $this->record->fresh(['items.product', 'customer'])
+                        );
+
+                        $this->record = $order;
+                        $this->fillForm();
+
+                        Notification::make()
+                            ->title('Order sent to Visma')
+                            ->body('Sales order ' . $order->visma_sales_order_number . ' synced successfully.')
+                            ->success()
+                            ->send();
+                    } catch (Throwable $exception) {
+                        report($exception);
+
+                        Notification::make()
+                            ->title('Failed to send order to Visma')
+                            ->body($exception->getMessage())
+                            ->danger()
+                            ->send();
+                    }
+                }),
             Actions\DeleteAction::make(),
         ];
     }

--- a/app/Filament/Resources/OrderResource/Pages/ListOrders.php
+++ b/app/Filament/Resources/OrderResource/Pages/ListOrders.php
@@ -3,7 +3,10 @@
 namespace App\Filament\Resources\OrderResource\Pages;
 
 use App\Filament\Resources\OrderResource;
+use App\Services\VismaOrderService;
 use Filament\Actions;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 
 class ListOrders extends ListRecords
@@ -13,6 +16,36 @@ class ListOrders extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('importFromVisma')
+                ->label('Import from Visma')
+                ->icon('heroicon-o-arrow-down-tray')
+                ->form([
+                    TextInput::make('order_number')
+                        ->label('Visma Order Number')
+                        ->required()
+                        ->maxLength(100),
+                ])
+                ->action(function (array $data): void {
+                    try {
+                        $order = app(VismaOrderService::class)->syncOrderFromVisma($data['order_number']);
+
+                        Notification::make()
+                            ->title('Order imported from Visma')
+                            ->body('Sales order ' . $order->visma_sales_order_number . ' has been synchronised.')
+                            ->success()
+                            ->send();
+
+                        $this->refreshTable();
+                    } catch (\Throwable $exception) {
+                        report($exception);
+
+                        Notification::make()
+                            ->title('Failed to import order from Visma')
+                            ->body($exception->getMessage())
+                            ->danger()
+                            ->send();
+                    }
+                }),
             Actions\CreateAction::make(),
         ];
     }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -9,9 +9,26 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Order extends Model
 {
     protected $fillable = [
-       'customer_id', 'invoice_address', 'invoice_city', 'invoice_postal_code',
-    'delivery_address', 'delivery_city', 'delivery_postal_code',
-    'total_amount', 'status', 'customer_price_class_id'
+        'customer_id',
+        'invoice_address',
+        'invoice_city',
+        'invoice_postal_code',
+        'delivery_address',
+        'delivery_city',
+        'delivery_postal_code',
+        'total_amount',
+        'status',
+        'customer_price_class_id',
+        'visma_sales_order_number',
+        'visma_status',
+        'visma_last_synced_at',
+        'visma_payload',
+    ];
+
+    protected $casts = [
+        'total_amount' => 'decimal:2',
+        'visma_payload' => 'array',
+        'visma_last_synced_at' => 'datetime',
     ];
 
     public function customer()

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -7,9 +7,25 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class OrderItem extends Model
 {
-    protected $fillable = ['order_id', 'product_id', 'quantity', 'price','discount_percent',
+    protected $fillable = [
+        'order_id',
+        'product_id',
+        'quantity',
+        'price',
+        'discount_percent',
         'discount_amount',
-        'discounted_price',];
+        'discounted_price',
+        'visma_line_number',
+    ];
+
+    protected $casts = [
+        'quantity' => 'integer',
+        'price' => 'decimal:2',
+        'discount_percent' => 'decimal:2',
+        'discount_amount' => 'decimal:2',
+        'discounted_price' => 'decimal:2',
+        'visma_line_number' => 'integer',
+    ];
 
     public function order(): BelongsTo
     {

--- a/app/Services/VismaOrderService.php
+++ b/app/Services/VismaOrderService.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Customer;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Products;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+class VismaOrderService
+{
+    private const BASE_URL = 'https://integration.visma.net/API/controller/api/v1';
+
+    private ?string $accessToken = null;
+
+    public function syncOrderFromVisma(string $orderNumber): Order
+    {
+        $orderNumber = trim($orderNumber);
+
+        if ($orderNumber === '') {
+            throw new RuntimeException('A Visma order number is required.');
+        }
+
+        $payload = $this->fetchOrderPayload($orderNumber);
+
+        if (!is_array($payload) || $payload === []) {
+            throw new RuntimeException(sprintf('Visma order "%s" could not be retrieved.', $orderNumber));
+        }
+
+        return DB::transaction(function () use ($payload) {
+            $order = $this->storeVismaOrderPayload($payload);
+
+            return $order->fresh(['items.product', 'customer']);
+        });
+    }
+
+    public function pushOrderToVisma(Order $order): Order
+    {
+        $order->loadMissing('items.product', 'customer');
+
+        if ($order->items->isEmpty()) {
+            throw new RuntimeException('Orders must contain at least one line before they can be sent to Visma.');
+        }
+
+        $payload = $this->buildSalesOrderPayload($order);
+        $client = $this->http();
+
+        try {
+            $response = $order->visma_sales_order_number
+                ? $client->put('/salesorder/' . urlencode($order->visma_sales_order_number), $payload)
+                : $client->post('/salesorder', $payload);
+        } catch (Throwable $exception) {
+            Log::error('Unexpected error while communicating with Visma.', [
+                'order_id' => $order->id,
+                'exception' => $exception,
+            ]);
+
+            throw new RuntimeException('Unable to communicate with Visma: ' . $exception->getMessage(), previous: $exception);
+        }
+
+        if ($response->failed()) {
+            Log::warning('Visma rejected order payload.', [
+                'order_id' => $order->id,
+                'payload' => $payload,
+                'response_status' => $response->status(),
+                'response_body' => $response->body(),
+            ]);
+
+            throw new RuntimeException(sprintf(
+                'Visma rejected the sales order (HTTP %d): %s',
+                $response->status(),
+                (string) $response->body()
+            ));
+        }
+
+        $responseBody = $response->json();
+        $vismaOrderNumber = data_get($responseBody, 'orderNo')
+            ?? data_get($responseBody, 'orderNumber')
+            ?? $order->visma_sales_order_number;
+
+        if (!filled($vismaOrderNumber)) {
+            throw new RuntimeException('Visma did not return a sales order number.');
+        }
+
+        return $this->syncOrderFromVisma($vismaOrderNumber);
+    }
+
+    protected function storeVismaOrderPayload(array $payload): Order
+    {
+        $orderNumber = data_get($payload, 'orderNo') ?? data_get($payload, 'orderNumber');
+        $status = data_get($payload, 'status');
+        $totals = data_get($payload, 'totals', []);
+        $details = data_get($payload, 'details', []);
+        $billingAddress = data_get($payload, 'billingAddress', []);
+        $shippingAddress = data_get($payload, 'shippingAddress', []);
+        $customerNumber = data_get($payload, 'customer.customerNo') ?? data_get($payload, 'customerNo');
+        $customerName = data_get($payload, 'customer.name') ?? data_get($payload, 'customerName');
+
+        if (!filled($customerNumber)) {
+            throw new RuntimeException('The Visma order payload does not contain a customer number.');
+        }
+
+        /** @var Customer $customer */
+        $customer = Customer::firstOrCreate(
+            ['number' => $customerNumber],
+            ['name' => $customerName ?: $customerNumber]
+        );
+
+        $orderAttributes = collect([
+            'customer_id' => $customer->id,
+            'customer_price_class_id' => $customer->customer_price_class_id,
+            'invoice_address' => data_get($billingAddress, 'addressLine1'),
+            'invoice_city' => data_get($billingAddress, 'city'),
+            'invoice_postal_code' => data_get($billingAddress, 'postalCode'),
+            'delivery_address' => data_get($shippingAddress, 'addressLine1'),
+            'delivery_city' => data_get($shippingAddress, 'city'),
+            'delivery_postal_code' => data_get($shippingAddress, 'postalCode'),
+            'status' => $status ?: 'pending',
+            'total_amount' => data_get($totals, 'orderTotal') ?? data_get($payload, 'orderTotal'),
+            'visma_sales_order_number' => $orderNumber,
+            'visma_status' => $status,
+            'visma_last_synced_at' => Carbon::now(),
+            'visma_payload' => $payload,
+        ])->filter(fn ($value) => !is_null($value))->all();
+
+        /** @var Order $order */
+        $order = Order::updateOrCreate(
+            ['visma_sales_order_number' => $orderNumber],
+            $orderAttributes
+        );
+
+        $this->syncOrderItems($order, is_array($details) ? $details : []);
+
+        $order->total_amount = $order->items->sum(function (OrderItem $item) {
+            return $item->quantity * $item->discounted_price;
+        });
+        $order->save();
+
+        return $order;
+    }
+
+    protected function syncOrderItems(Order $order, array $details): void
+    {
+        $existingItemIds = [];
+
+        foreach ($details as $detail) {
+            $inventoryId = data_get($detail, 'inventoryId');
+
+            if (!filled($inventoryId)) {
+                continue;
+            }
+
+            $product = Products::query()
+                ->where('inventory_id', $inventoryId)
+                ->orWhere('sku', $inventoryId)
+                ->first();
+
+            if (!$product) {
+                throw new RuntimeException(sprintf(
+                    'Product "%s" referenced by Visma order could not be found locally.',
+                    $inventoryId
+                ));
+            }
+
+            $quantity = (float) data_get($detail, 'quantity', 1);
+            $unitPrice = (float) data_get($detail, 'unitPrice', 0);
+            $discountPercent = (float) data_get($detail, 'discPct', 0);
+            $discountAmount = (float) data_get($detail, 'discountAmount', 0);
+            $lineTotal = (float) data_get($detail, 'lineTotal', 0);
+            $lineNumber = data_get($detail, 'lineNbr');
+
+            $discountedUnitPrice = $unitPrice;
+
+            if ($discountPercent !== 0.0) {
+                $discountedUnitPrice = $unitPrice * (1 - $discountPercent / 100);
+            } elseif ($discountAmount > 0 && $quantity > 0) {
+                $discountedUnitPrice = ($unitPrice * $quantity - $discountAmount) / max($quantity, 1);
+            } elseif ($lineTotal > 0 && $quantity > 0) {
+                $discountedUnitPrice = $lineTotal / max($quantity, 1);
+            }
+
+            $calculatedDiscountAmount = max(0, ($unitPrice - $discountedUnitPrice) * $quantity);
+            if ($discountAmount <= 0 && $calculatedDiscountAmount > 0) {
+                $discountAmount = $calculatedDiscountAmount;
+            }
+
+            $orderItem = $order->items()
+                ->when($lineNumber !== null, function ($query) use ($lineNumber) {
+                    $query->where('visma_line_number', $lineNumber);
+                })
+                ->where('product_id', $product->id)
+                ->first();
+
+            if (!$orderItem) {
+                $orderItem = new OrderItem();
+                $orderItem->order_id = $order->id;
+                $orderItem->product_id = $product->id;
+            }
+
+            $orderItem->fill([
+                'quantity' => $quantity,
+                'price' => $unitPrice,
+                'discount_percent' => $discountPercent,
+                'discount_amount' => $discountAmount,
+                'discounted_price' => $discountedUnitPrice,
+                'visma_line_number' => $lineNumber,
+            ]);
+            $orderItem->save();
+
+            $existingItemIds[] = $orderItem->id;
+        }
+
+        $order->items()->whereNotIn('id', $existingItemIds)->delete();
+        $order->load('items');
+    }
+
+    protected function buildSalesOrderPayload(Order $order): array
+    {
+        $details = [];
+
+        foreach ($order->items as $index => $item) {
+            $product = $item->product;
+
+            if (!$product) {
+                throw new RuntimeException('All order lines must have an associated product before sending to Visma.');
+            }
+
+            $inventoryId = $product->inventory_id ?: $product->sku;
+
+            if (!filled($inventoryId)) {
+                throw new RuntimeException(sprintf('Product "%s" does not have an inventory ID or SKU.', $product->name));
+            }
+
+            $line = [
+                'lineNbr' => $item->visma_line_number ?? ($index + 1),
+                'inventoryId' => $inventoryId,
+                'quantity' => (float) $item->quantity,
+                'unitPrice' => (float) $item->price,
+            ];
+
+            if ($item->discount_percent) {
+                $line['discPct'] = (float) $item->discount_percent;
+            }
+
+            if ($item->discount_amount) {
+                $line['discountAmount'] = (float) $item->discount_amount;
+            }
+
+            $details[] = $line;
+        }
+
+        $payload = [
+            'orderNo' => $order->visma_sales_order_number,
+            'orderDate' => optional($order->created_at)->format('Y-m-d') ?? Carbon::now()->format('Y-m-d'),
+            'status' => $order->status,
+            'customer' => [
+                'customerNo' => $order->customer->number,
+            ],
+            'details' => $details,
+            'billingAddress' => array_filter([
+                'addressLine1' => $order->invoice_address,
+                'postalCode' => $order->invoice_postal_code,
+                'city' => $order->invoice_city,
+            ], fn ($value) => filled($value)),
+            'shippingAddress' => array_filter([
+                'addressLine1' => $order->delivery_address,
+                'postalCode' => $order->delivery_postal_code,
+                'city' => $order->delivery_city,
+            ], fn ($value) => filled($value)),
+            'currencyId' => env('VISMA_DEFAULT_CURRENCY', 'NOK'),
+        ];
+
+        return Arr::where($payload, fn ($value) => !is_null($value));
+    }
+
+    protected function fetchOrderPayload(string $orderNumber): array
+    {
+        $response = $this->http()->get('/salesorder/' . urlencode($orderNumber));
+
+        if ($response->failed()) {
+            throw new RuntimeException(sprintf(
+                'Failed to retrieve Visma order "%s" (HTTP %d): %s',
+                $orderNumber,
+                $response->status(),
+                (string) $response->body()
+            ));
+        }
+
+        $payload = $response->json();
+
+        if (!is_array($payload)) {
+            throw new RuntimeException('Visma returned an unexpected response when fetching the order.');
+        }
+
+        return $payload;
+    }
+
+    protected function http(): PendingRequest
+    {
+        return Http::withToken($this->getAccessToken())
+            ->acceptJson()
+            ->baseUrl(self::BASE_URL);
+    }
+
+    protected function getAccessToken(): string
+    {
+        if ($this->accessToken) {
+            return $this->accessToken;
+        }
+
+        $clientId = env('VISMA_CLIENT_ID');
+        $clientSecret = env('VISMA_CLIENT_SECRET');
+        $tenantId = env('VISMA_TENANT_ID', env('VISMA_TENANT_ID_LIVE'));
+
+        if (!filled($clientId) || !filled($clientSecret) || !filled($tenantId)) {
+            throw new RuntimeException('Visma credentials are not configured.');
+        }
+
+        $response = Http::asForm()->post('https://connect.visma.com/connect/token', [
+            'grant_type' => 'client_credentials',
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'tenant_id' => $tenantId,
+            'scope' => 'vismanet_erp_service_api:read vismanet_erp_service_api:write',
+        ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException(sprintf(
+                'Unable to retrieve Visma access token (HTTP %d): %s',
+                $response->status(),
+                (string) $response->body()
+            ));
+        }
+
+        $token = $response->json('access_token');
+
+        if (!filled($token)) {
+            throw new RuntimeException('Visma did not return an access token.');
+        }
+
+        return $this->accessToken = $token;
+    }
+}

--- a/database/migrations/2025_09_29_190000_add_visma_fields_to_orders_and_order_items_table.php
+++ b/database/migrations/2025_09_29_190000_add_visma_fields_to_orders_and_order_items_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->string('visma_sales_order_number')->nullable()->after('status');
+            $table->string('visma_status')->nullable()->after('visma_sales_order_number');
+            $table->timestamp('visma_last_synced_at')->nullable()->after('visma_status');
+            $table->json('visma_payload')->nullable()->after('visma_last_synced_at');
+            $table->index('visma_sales_order_number', 'orders_visma_sales_order_number_index');
+        });
+
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->unsignedInteger('visma_line_number')->nullable()->after('discounted_price');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropColumn('visma_line_number');
+        });
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropIndex('orders_visma_sales_order_number_index');
+            $table->dropColumn([
+                'visma_sales_order_number',
+                'visma_status',
+                'visma_last_synced_at',
+                'visma_payload',
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a dedicated VismaOrderService to import existing Visma sales orders and push local orders back to Visma
- enhance the Filament order resource to manage Visma metadata, discounts, and provide import/export actions across list, create, and edit flows
- persist Visma identifiers and sync payloads on orders and order items through new database fields and model casts

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b4c35f2c8323ac8df54a1f5ffd5b